### PR TITLE
Bug fix fan controller EMC2302

### DIFF
--- a/main/EMC2302.c
+++ b/main/EMC2302.c
@@ -50,10 +50,10 @@ uint16_t EMC2302_get_fan_speed(uint8_t devicenum)
     ESP_ERROR_CHECK(i2c_bitaxe_register_read(emc2302_dev_handle,TACH_LSB_REG, &tach_lsb, 1));
     ESP_ERROR_CHECK(i2c_bitaxe_register_read(emc2302_dev_handle,TACH_MSB_REG, &tach_msb, 1));
 
-    //ESP_LOGI(TAG, "Raw Fan Speed[%d] = %02X %02X", devicenum, tach_msb, tach_lsb);
+    ESP_LOGI(TAG, "Raw Fan Speed[%d] = %02X %02X", devicenum, tach_msb, tach_lsb);
     RPM = (tach_msb << 5) + ((tach_lsb >> 3) & 0x1F);
     RPM = EMC2302_FAN_RPM_NUMERATOR / RPM;
-    //ESP_LOGI(TAG, "Fan Speed[%d] = %d RPM", devicenum, RPM);
+    ESP_LOGI(TAG, "Fan Speed[%d] = %d RPM", devicenum, RPM);
 
     return RPM;
 }

--- a/main/EMC2302.c
+++ b/main/EMC2302.c
@@ -30,8 +30,8 @@ esp_err_t EMC2302_init(bool invertPolarity) {
     //ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2302_dev_handle, EMC2302_FAN1_CONFIG1, 0b00001011));
     //fan config read without write: 2B = 00101011
 
-    // Setting fan range to 00 and edge to 00
-    ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2302_dev_handle, EMC2302_FAN1_CONFIG1, 0b00000011));
+    // Setting fan range to 00 and edge to 11
+    ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2302_dev_handle, EMC2302_FAN1_CONFIG1, 0b00011011));
 
     return ESP_OK;
 }
@@ -59,7 +59,7 @@ uint16_t EMC2302_get_fan_speed(uint8_t devicenum)
 
     ESP_LOGI(TAG, "Raw Fan Speed[%d] = %02X %02X", devicenum, tach_msb, tach_lsb);  // DEBUG
     RPM = (tach_msb << 5) + ((tach_lsb >> 3) & 0x1F);
-    RPM = EMC2302_FAN_RPM_NUMERATOR / RPM / 2;              //edge 1 > 0.5 factor
+    RPM = EMC2302_FAN_RPM_NUMERATOR / RPM * 2;              //edge poles 4 ->  factor 2
     ESP_LOGI(TAG, "Fan Speed[%d] = %d RPM", devicenum, RPM);                        // DEBUG
 
     // DEBUG: get fan config

--- a/main/EMC2302.c
+++ b/main/EMC2302.c
@@ -26,6 +26,10 @@ esp_err_t EMC2302_init(bool invertPolarity) {
         ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2302_dev_handle, EMC2302_PWM_POLARITY, 0b00011111));
     }
 
+    // Setting fan range to 00
+    ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2302_dev_handle, EMC2302_FAN1_CONFIG1, 0b00001011));
+    //fan config read without write: 2B = 00101011
+
     return ESP_OK;
 }
 

--- a/main/EMC2302.c
+++ b/main/EMC2302.c
@@ -50,10 +50,17 @@ uint16_t EMC2302_get_fan_speed(uint8_t devicenum)
     ESP_ERROR_CHECK(i2c_bitaxe_register_read(emc2302_dev_handle,TACH_LSB_REG, &tach_lsb, 1));
     ESP_ERROR_CHECK(i2c_bitaxe_register_read(emc2302_dev_handle,TACH_MSB_REG, &tach_msb, 1));
 
-    ESP_LOGI(TAG, "Raw Fan Speed[%d] = %02X %02X", devicenum, tach_msb, tach_lsb);
+    ESP_LOGI(TAG, "Raw Fan Speed[%d] = %02X %02X", devicenum, tach_msb, tach_lsb);  // DEBUG
     RPM = (tach_msb << 5) + ((tach_lsb >> 3) & 0x1F);
     RPM = EMC2302_FAN_RPM_NUMERATOR / RPM;
-    ESP_LOGI(TAG, "Fan Speed[%d] = %d RPM", devicenum, RPM);
+    ESP_LOGI(TAG, "Fan Speed[%d] = %d RPM", devicenum, RPM);                        // DEBUG
+
+    // DEBUG: get fan config
+    uint8_t fan_conf;
+    uint8_t FAN1_CONFIG1 = EMC2302_FAN1_CONFIG1 + (devicenum * 0x10);
+    ESP_ERROR_CHECK(i2c_bitaxe_register_read(emc2302_dev_handle, FAN1_CONFIG1, &fan_conf, 1));
+    ESP_LOGI(TAG, "Fan config[%d] = %02X", devicenum, fan_conf);
+    // DEBUG
 
     return RPM;
 }

--- a/main/EMC2302.c
+++ b/main/EMC2302.c
@@ -27,8 +27,11 @@ esp_err_t EMC2302_init(bool invertPolarity) {
     }
 
     // Setting fan range to 00
-    ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2302_dev_handle, EMC2302_FAN1_CONFIG1, 0b00001011));
+    //ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2302_dev_handle, EMC2302_FAN1_CONFIG1, 0b00001011));
     //fan config read without write: 2B = 00101011
+
+    // Setting fan range to 00 and edge to 00
+    ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2302_dev_handle, EMC2302_FAN1_CONFIG1, 0b00000011));
 
     return ESP_OK;
 }
@@ -56,7 +59,7 @@ uint16_t EMC2302_get_fan_speed(uint8_t devicenum)
 
     ESP_LOGI(TAG, "Raw Fan Speed[%d] = %02X %02X", devicenum, tach_msb, tach_lsb);  // DEBUG
     RPM = (tach_msb << 5) + ((tach_lsb >> 3) & 0x1F);
-    RPM = EMC2302_FAN_RPM_NUMERATOR / RPM;
+    RPM = EMC2302_FAN_RPM_NUMERATOR / RPM / 2;              //edge 1 > 0.5 factor
     ESP_LOGI(TAG, "Fan Speed[%d] = %d RPM", devicenum, RPM);                        // DEBUG
 
     // DEBUG: get fan config

--- a/main/EMC2302.c
+++ b/main/EMC2302.c
@@ -26,12 +26,9 @@ esp_err_t EMC2302_init(bool invertPolarity) {
         ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2302_dev_handle, EMC2302_PWM_POLARITY, 0b00011111));
     }
 
-    // Setting fan range to 00
-    //ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2302_dev_handle, EMC2302_FAN1_CONFIG1, 0b00001011));
-    //fan config read without write: 2B = 00101011
-
-    // Setting fan range to 00 and edge to 11
-    ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2302_dev_handle, EMC2302_FAN1_CONFIG1, 0b00011011));
+    // Set fan range to 00: 500 RPM minimum, TACH count multiplier = 1
+    // fan config default before register write: 2B = 00101011
+    ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2302_dev_handle, EMC2302_FAN1_CONFIG1, 0b00001011));
 
     return ESP_OK;
 }
@@ -57,16 +54,16 @@ uint16_t EMC2302_get_fan_speed(uint8_t devicenum)
     ESP_ERROR_CHECK(i2c_bitaxe_register_read(emc2302_dev_handle,TACH_LSB_REG, &tach_lsb, 1));
     ESP_ERROR_CHECK(i2c_bitaxe_register_read(emc2302_dev_handle,TACH_MSB_REG, &tach_msb, 1));
 
-    ESP_LOGI(TAG, "Raw Fan Speed[%d] = %02X %02X", devicenum, tach_msb, tach_lsb);  // DEBUG
+    //ESP_LOGI(TAG, "Raw Fan Speed[%d] = %02X %02X", devicenum, tach_msb, tach_lsb);  // DEBUG
     RPM = (tach_msb << 5) + ((tach_lsb >> 3) & 0x1F);
-    RPM = EMC2302_FAN_RPM_NUMERATOR / RPM * 2;              //edge poles 4 ->  factor 2
-    ESP_LOGI(TAG, "Fan Speed[%d] = %d RPM", devicenum, RPM);                        // DEBUG
+    RPM = EMC2302_FAN_RPM_NUMERATOR / RPM;
+    //ESP_LOGI(TAG, "Fan Speed[%d] = %d RPM", devicenum, RPM);                        // DEBUG
 
     // DEBUG: get fan config
-    uint8_t fan_conf;
-    uint8_t FAN1_CONFIG1 = EMC2302_FAN1_CONFIG1 + (devicenum * 0x10);
-    ESP_ERROR_CHECK(i2c_bitaxe_register_read(emc2302_dev_handle, FAN1_CONFIG1, &fan_conf, 1));
-    ESP_LOGI(TAG, "Fan config[%d] = %02X", devicenum, fan_conf);
+    //uint8_t fan_conf;
+    //uint8_t FAN1_CONFIG1 = EMC2302_FAN1_CONFIG1 + (devicenum * 0x10);
+    //ESP_ERROR_CHECK(i2c_bitaxe_register_read(emc2302_dev_handle, FAN1_CONFIG1, &fan_conf, 1));
+    //ESP_LOGI(TAG, "Fan config[%d] = %02X", devicenum, fan_conf);
     // DEBUG
 
     return RPM;

--- a/main/EMC2302.h
+++ b/main/EMC2302.h
@@ -32,8 +32,8 @@
 #define EMC2302_FAN1_DRV_FAIL_HIGH 0x3B ///< Fan 1 drive fail band high byte
 #define EMC2302_TACH1_TARGET_LSB 0x3C   ///< Tach 1 target low byte
 #define EMC2302_TACH1_TARGET_MSB 0x3D   ///< Tach 1 target high byte
-#define EMC2302_TACH1_LSB 0x3E          ///< Tach 1 reading low byte
-#define EMC2302_TACH1_MSB 0x3F          ///< Tach 1 reading high byte
+#define EMC2302_TACH1_MSB 0x3E          ///< Tach 1 reading high byte
+#define EMC2302_TACH1_LSB 0x3F          ///< Tach 1 reading low byte
 
 #define EMC2302_FAN2_SETTING 0x40       ///< Fan 2 setting
 #define EMC2302_PWM2_DIVIDE 0x41        ///< PWM 2 divider
@@ -48,8 +48,8 @@
 #define EMC2302_FAN2_DRV_FAIL_HIGH 0x4B ///< Fan 2 drive fail band high byte
 #define EMC2302_TACH2_TARGET_LSB 0x4C   ///< Tach 2 target low byte
 #define EMC2302_TACH2_TARGET_MSB 0x4D   ///< Tach 2 target high byte
-#define EMC2302_TACH2_LSB 0x4E          ///< Tach 2 reading low byte
-#define EMC2302_TACH2_MSB 0x4F          ///< Tach 2 reading high byte
+#define EMC2302_TACH2_MSB 0x4E          ///< Tach 2 reading high byte
+#define EMC2302_TACH2_LSB 0x4F          ///< Tach 2 reading low byte
 
 #define EMC2302_FAN_RPM_NUMERATOR 3932160 ///< Conversion unit to convert LSBs to fan RPM
 #define _TEMP_LSB 0.125                   ///< single bit value for internal temperature readings


### PR DESCRIPTION
The configuration of the fan controller EMC2302 had to be adapted as the reading of the RPM values was implemented incorrectly.
Incidentally, the minimum measurable RPM value is 500rpm.

Manual EMC2302: https://www.microchip.com/en-us/product/emc2302#Documentation, see `EMC2301/2/3/5 Data Sheet`